### PR TITLE
fix custody bluna docs

### DIFF
--- a/docs/smart-contracts/money-market/custody-bluna-specific.md
+++ b/docs/smart-contracts/money-market/custody-bluna-specific.md
@@ -230,7 +230,7 @@ pub enum ExecuteMsg {
 
 Withdraws accrued rewards from the bLuna Contract, swaps rewards to the appropriate stablecoin denomination. Can only be issued by `Overseer`.
 
-Afterwards, distributes swapped rewards to depositors by sending swapped rewards to `Market`. If the deposit rate during the last epoch is above the target deposit rate, then a portion of the rewards are set aside as a yield reserve, which are sent to `Overseer`.&#x20;
+Afterwards, sends swapped rewards to `Overseer`. If the deposit rate during the last epoch is below the threshold deposit rate, then a portion of the rewards are sent to `Market`.&#x20;
 
 :::::{tab-set}
 ::::{tab-item} Rust


### PR DESCRIPTION
The revision is based on the source codes below:

sends swapped rewards to `Overseer`. 
(https://github.com/Anchor-Protocol/money-market-contracts/blob/main/contracts/custody_bluna/src/distribution.rs#L74 )

If the deposit rate during the last epoch is below the threshold deposit rate, then a portion of the rewards are sent to `Market`.
(https://github.com/Anchor-Protocol/money-market-contracts/blob/main/contracts/overseer/src/contract.rs#L558)

